### PR TITLE
Release nodejs-googleapis-common v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+[npm history][1]
+
+[1]: https://www.npmjs.com/package/nodejs-googleapis-common?activeTab=versions
+
+## v0.1.0
+
+Initial release 🎉
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis-common",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "A common tooling library used by the googleapis npm module. You probably don't want to use this directly.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
This pull request was generated using releasetool.