### PR TITLE
Release nodejs-googleapis-common v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+[npm history][1]
+
+[1]: https://www.npmjs.com/package/nodejs-googleapis-common?activeTab=versions
+
+## v0.2.1
+
+### Fixes
+- fix: use the latest google-auth-library (#4)
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis-common",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A common tooling library used by the googleapis npm module. You probably don't want to use this directly.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
This pull request was generated using releasetool.