### PR TITLE
Release nodejs-googleapis-common v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://www.npmjs.com/package/nodejs-googleapis-common?activeTab=versions
 
+## v0.3.0
+
+This release uses the 2.0 release of `google-auth-library`.  A summary of these changes (including breaking changes) can be found in the [release notes](https://github.com/google/google-auth-library-nodejs/releases/tag/v2.0.0).
+
+### Dependencies
+- Upgrade to google-auth-library 2.0 (#6)
+
 ## v0.2.1
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis-common",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A common tooling library used by the googleapis npm module. You probably don't want to use this directly.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
This pull request was generated using releasetool.