### PR TITLE
fix: Pin @types/sinon to last compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "mocha": "^5.2.0",
     "nock": "^10.0.0",
     "source-map-support": "^0.5.8",
-    "typescript": "~3.1.0"
+    "typescript": "~3.1.0",
+    "@types/sinon": "5.0.5"
   },
   "dependencies": {
     "axios": "^0.18.0",


### PR DESCRIPTION
@types/sinon had an update over the weekend which broke many of our tests. The *real* fix is [something like this](https://github.com/googleapis/nodejs-spanner/pull/441/files), but for now, this should fix our broken CI and give us some breathing room.