### PR TITLE
Fix partial upload (of a stream) issue in the event when access token is refreshed automatically.

### DIFF
--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -200,7 +200,7 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
             }
           });
           part.body.pipe(pStream).pipe(rStream, {end: false});
-          part.body.on('end', () => {
+          pStream.on('end', () => {
             rStream.push('\r\n');
             rStream.push(finale);
             rStream.push(null);


### PR DESCRIPTION
Fixes googleapis/google-api-nodejs-client/issues/1457 

- [x] Tests and linter pass

Prevent premature closure of `rStream`
* "Switch" `.on('end')` listener from `part.body` (readable stream) to `pStream` to make sure that `rStream` is not closed before it consumed all data from `pStream`.
