### PR TITLE
DO NOT MERGE: feat: make it ready for use in browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 package-lock.json
 .vscode
 yarn.lock
+dist

--- a/package.json
+++ b/package.json
@@ -41,13 +41,17 @@
     "jsdoc": "^3.5.5",
     "mocha": "^5.2.0",
     "nock": "^10.0.0",
+    "null-loader": "^0.1.1",
     "nyc": "^13.1.0",
     "source-map-support": "^0.5.8",
-    "typescript": "~3.2.0"
+    "ts-loader": "^5.3.2",
+    "typescript": "~3.2.0",
+    "webpack": "^4.28.3",
+    "webpack-cli": "^3.2.0"
   },
   "dependencies": {
     "axios": "^0.18.0",
-    "google-auth-library": "^2.0.0",
+    "google-auth-library": "googleapis/google-auth-library-nodejs#webbbpackkk",
     "pify": "^4.0.0",
     "qs": "^6.5.2",
     "url-template": "^2.0.8",

--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -14,6 +14,7 @@
 import {AxiosPromise} from 'axios';
 import {DefaultTransporter, OAuth2Client} from 'google-auth-library';
 import {BodyResponseCallback} from 'google-auth-library/build/src/transporters';
+import {isBrowser} from './isbrowser';
 import * as qs from 'qs';
 import * as stream from 'stream';
 import * as urlTemplate from 'url-template';
@@ -228,7 +229,9 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
   // https://github.com/google/google-api-nodejs-client/issues/991
   options.maxContentLength = options.maxContentLength || maxContentLength;
   options.headers['Accept-Encoding'] = 'gzip';
-  options.headers['User-Agent'] = USER_AGENT;
+  if (!isBrowser()) {
+    options.headers['User-Agent'] = USER_AGENT;
+  }
 
   // By default Axios treats any 2xx as valid, and all non 2xx status
   // codes as errors.  This is a problem for HTTP 304s when used along

--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -14,13 +14,13 @@
 import {AxiosPromise} from 'axios';
 import {DefaultTransporter, OAuth2Client} from 'google-auth-library';
 import {BodyResponseCallback} from 'google-auth-library/build/src/transporters';
-import {isBrowser} from './isbrowser';
 import * as qs from 'qs';
 import * as stream from 'stream';
 import * as urlTemplate from 'url-template';
 import * as uuid from 'uuid';
 
 import {APIRequestParams, GlobalOptions} from './api';
+import {isBrowser} from './isbrowser';
 import {SchemaParameters} from './schema';
 
 const maxContentLength = Math.pow(2, 31);

--- a/src/isbrowser.ts
+++ b/src/isbrowser.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function isBrowser(): boolean {
+  return typeof (window) !== 'undefined';
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
+    "lib": ["es2015", "dom"],
     "rootDir": ".",
     "outDir": "build"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Use `npm run webpack` to produce Webpack bundle for this library.
+
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.ts',
+  resolve: {
+    extensions: ['.ts', '.js', '.json'],
+    alias: {
+      '../../package.json': path.resolve(__dirname, 'package.json'),
+    },
+  },
+  output: {
+    library: 'GoogleapisCommon',
+    filename: 'googleapis-common.min.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  node: {
+    child_process: 'empty',
+    fs: 'empty',
+    crypto: 'empty',
+  },
+  module: {
+    rules: [
+      {
+        test: /src\/crypto\/node\/crypto/,
+        use: 'null-loader',
+      },
+      {
+        test: /node_modules\/https-proxy-agent\//,
+        use: 'null-loader',
+      },
+      {
+        test: /node_modules\/gtoken\//,
+        use: 'null-loader',
+      },
+      {
+        test: /node_modules\/pkginfo\//,
+        use: 'null-loader',
+      },
+      {
+        test: /node_modules\/semver\//,
+        use: 'null-loader',
+      },
+      {
+        test: /\.ts$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  mode: 'production',
+  plugins: [],
+};


### PR DESCRIPTION
This will wait for https://github.com/googleapis/google-auth-library-nodejs/pull/371. I don't think we need more changes here in this library, other than removing the `User-Agent` header which is impossible to set from inside the browser.