### PR TITLE
feat: export AuthPlus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 package-lock.json
 .vscode
 yarn.lock
+.coverage
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis-common",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A common tooling library used by the googleapis npm module. You probably don't want to use this directly.",
   "repository": "googleapis/nodejs-googleapis-common",
   "main": "build/src/index.js",

--- a/src/authplus.ts
+++ b/src/authplus.ts
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Compute, GoogleAuth, JWT, OAuth2Client} from 'google-auth-library';
+
+export class AuthPlus extends GoogleAuth {
+  // tslint:disable-next-line: variable-name
+  JWT = JWT;
+  // tslint:disable-next-line: variable-name
+  Compute = Compute;
+  // tslint:disable-next-line: variable-name
+  OAuth2 = OAuth2Client;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@
 export {APIEndpoint, APIRequestContext, APIRequestParams, BodyResponseCallback, GlobalOptions, GoogleConfigurable, MethodOptions, ServiceOptions} from './api';
 export {getAPI} from './apiIndex';
 export {createAPIRequest} from './apirequest';
+export {AuthPlus} from './authplus';
 export {Discovery, DiscoveryOptions, EndpointCreator} from './discovery';
 export {Endpoint, Target} from './endpoint';
 export {FragmentResponse, HttpMethod, ParameterFormat, Schema, SchemaItem, SchemaItems, SchemaMethod, SchemaMethods, SchemaParameter, SchemaParameters, SchemaResource, SchemaResources, Schemas, SchemaType} from './schema';


### PR DESCRIPTION
Export `AuthPlus` (copied from  to make it possible to use it from google-api-nodejs-client micropackages, and release v0.5.0.

Copied from here:

https://github.com/googleapis/google-api-nodejs-client/blob/7e07d11f2c0573f70538adebf79d46f4e63515cd/src/googleapis.ts#L14-L26

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
