### PR TITLE
Release googleapis-common v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [1]: https://www.npmjs.com/package/nodejs-googleapis-common?activeTab=versions
 
+## v0.7.2
+
+01-26-2019 21:18 PST
+
+- fix: explicit push of finale for multipart/related streams to fix node.js 6 ([#82](https://github.com/googleapis/nodejs-googleapis-common/pull/82))
+
 ## v0.7.1
 
 01-22-2019 11:22 PST

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis-common",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A common tooling library used by the googleapis npm module. You probably don't want to use this directly.",
   "repository": "googleapis/nodejs-googleapis-common",
   "main": "build/src/index.js",

--- a/samples/package.json
+++ b/samples/package.json
@@ -11,7 +11,7 @@
     "test": "echo \"There are no sample tests 👻\""
   },
   "dependencies": {
-    "googleapis-common": "^0.7.1"
+    "googleapis-common": "^0.7.2"
   },
   "devDependencies": {
     "mocha": "^5.2.0"


### PR DESCRIPTION
This pull request was generated using releasetool.