### PR TITLE
feat: retry requests by default

### DIFF
--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -250,6 +250,9 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
     };
   }
 
+  // Retry by default
+  options.retry = options.retry === undefined ? true : options.retry;
+
   // Combine the GaxiosOptions options passed with this specific
   // API call witht the global options configured at the API Context
   // level, or at the global level.

--- a/test/test.apirequest.ts
+++ b/test/test.apirequest.ts
@@ -174,4 +174,18 @@ describe('createAPIRequest', () => {
       assert.strictEqual(totalBytesSent, totalBytesReceived);
     });
   });
+
+  describe('options', () => {
+    it('should retry GET requests by default', async () => {
+      const scope = nock(url).get('/').reply(500).get('/').reply(200);
+      await createAPIRequest<FakeParams>({
+        options: {url},
+        params: {},
+        requiredParams: [],
+        pathParams: [],
+        context: fakeContext
+      });
+      scope.done();
+    });
+  });
 });


### PR DESCRIPTION
BREAKING CHANGE: This change enables HTTP retries by default.  The retry logic matches the defaults for [gaxios](https://github.com/JustinBeckwith/gaxios):

```js
{
  // The amount of time to initially delay the retry
  retryDelay: 100;

  // The HTTP Methods that will be automatically retried.
  httpMethodsToRetry: ['GET','PUT','HEAD','OPTIONS','DELETE']

  // The HTTP response status codes that will automatically be retried.
  statusCodesToRetry: [[100, 199], [429, 429], [500, 599]];
}
```

The behavior can be disabled by setting `retry` to `false` in the request config.

Fixes https://github.com/googleapis/google-api-nodejs-client/issues/482.