### PR TITLE
fix: use deep merge for headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "extend": "^3.0.2",
     "gaxios": "^2.0.1",
     "google-auth-library": "^4.2.0",
-    "pify": "^4.0.0",
     "qs": "^6.7.0",
     "url-template": "^2.0.8",
     "uuid": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@compodoc/compodoc": "^1.1.9",
     "@types/chai": "^4.1.7",
     "@types/execa": "^0.9.0",
+    "@types/extend": "^3.0.1",
     "@types/mocha": "^5.2.7",
     "@types/mv": "^2.1.0",
     "@types/ncp": "^2.0.1",
@@ -71,8 +72,10 @@
     "webpack-cli": "^3.3.4"
   },
   "dependencies": {
+    "extend": "^3.0.2",
     "gaxios": "^2.0.1",
     "google-auth-library": "^4.2.0",
+    "pify": "^4.0.0",
     "qs": "^6.7.0",
     "url-template": "^2.0.8",
     "uuid": "^3.3.2"

--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -17,6 +17,7 @@ import * as qs from 'qs';
 import * as stream from 'stream';
 import * as urlTemplate from 'url-template';
 import * as uuid from 'uuid';
+import * as extend from 'extend';
 
 import {APIRequestParams, BodyResponseCallback} from './api';
 import {isBrowser} from './isbrowser';
@@ -225,7 +226,7 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
     options.data = resource || undefined;
   }
 
-  options.headers = headers;
+  options.headers = extend(true, options.headers || {}, headers);
   options.params = params;
   if (!isBrowser()) {
     options.headers!['Accept-Encoding'] = 'gzip';
@@ -262,7 +263,8 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
   // Combine the GaxiosOptions options passed with this specific
   // API call witht the global options configured at the API Context
   // level, or at the global level.
-  const mergedOptions = Object.assign(
+  const mergedOptions = extend(
+    true,
     {},
     parameters.context.google ? parameters.context.google._options : {},
     parameters.context._options,

--- a/test/test.apirequest.ts
+++ b/test/test.apirequest.ts
@@ -226,7 +226,6 @@ describe('createAPIRequest', () => {
         },
       });
       scope.done();
-      console.log(res.config.headers);
       assert.strictEqual(res.config.headers!['Global-Header'], 'global');
       assert.strictEqual(res.config.headers!['Local-Header'], 'local');
     });

--- a/test/test.apirequest.ts
+++ b/test/test.apirequest.ts
@@ -199,5 +199,36 @@ describe('createAPIRequest', () => {
       });
       scope.done();
     });
+
+    it('should merge headers from global and local config', async () => {
+      const scope = nock(url)
+        .get('/')
+        .reply(200);
+      const res = await createAPIRequest<FakeParams>({
+        options: {
+          url,
+          headers: {
+            'Local-Header': 'local',
+          },
+        },
+        params: {},
+        requiredParams: [],
+        pathParams: [],
+        context: {
+          _options: {},
+          google: {
+            _options: {
+              headers: {
+                'Global-Header': 'global',
+              },
+            },
+          },
+        },
+      });
+      scope.done();
+      console.log(res.config.headers);
+      assert.strictEqual(res.config.headers!['Global-Header'], 'global');
+      assert.strictEqual(res.config.headers!['Local-Header'], 'local');
+    });
   });
 });


### PR DESCRIPTION
This fixes an upstream bug where headers offered via global options are clobbered and ignored.