### PR TITLE
feat!: expose GoogleAuth constructor on AuthPlus class

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "extend": "^3.0.2",
     "gaxios": "^2.0.1",
-    "google-auth-library": "^5.0.0",
+    "google-auth-library": "^5.1.0",
     "qs": "^6.7.0",
     "url-template": "^2.0.8",
     "uuid": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "extend": "^3.0.2",
     "gaxios": "^2.0.1",
-    "google-auth-library": "^4.2.5",
+    "google-auth-library": "^5.0.0",
     "qs": "^6.7.0",
     "url-template": "^2.0.8",
     "uuid": "^3.3.2"

--- a/src/authplus.ts
+++ b/src/authplus.ts
@@ -11,7 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Compute, GoogleAuth, JWT, OAuth2Client} from 'google-auth-library';
+import {
+  Compute,
+  GoogleAuth,
+  GoogleAuthOptions,
+  JWT,
+  OAuth2Client,
+  UserRefreshClient,
+} from 'google-auth-library';
+import {ProjectIdCallback} from 'google-auth-library/build/src/auth/googleauth';
 
 export class AuthPlus extends GoogleAuth {
   // tslint:disable-next-line: variable-name
@@ -20,4 +28,37 @@ export class AuthPlus extends GoogleAuth {
   Compute = Compute;
   // tslint:disable-next-line: variable-name
   OAuth2 = OAuth2Client;
+  // tslint:disable-next-line: variable-name
+  GoogleAuth = GoogleAuth;
+
+  private _cachedAuth: GoogleAuth | null = null;
+
+  /**
+   * Override getClient(), memoizing an instance of auth for
+   * subsequent calls to getProjectId().
+   */
+  async getClient(
+    options?: GoogleAuthOptions
+  ): Promise<Compute | JWT | UserRefreshClient> {
+    this._cachedAuth = new GoogleAuth(options);
+    return this._cachedAuth.getClient();
+  }
+
+  /**
+   * Override getProjectId(), using the most recently configured
+   * auth instance when fetching projectId.
+   */
+  getProjectId(): Promise<string>;
+  getProjectId(callback: ProjectIdCallback): void;
+  getProjectId(callback?: ProjectIdCallback): Promise<string | null> | void {
+    if (callback) {
+      return this._cachedAuth
+        ? this._cachedAuth.getProjectId(callback)
+        : super.getProjectId(callback);
+    } else {
+      return this._cachedAuth
+        ? this._cachedAuth.getProjectId()
+        : super.getProjectId();
+    }
+  }
 }

--- a/src/authplus.ts
+++ b/src/authplus.ts
@@ -17,9 +17,9 @@ import {
   GoogleAuthOptions,
   JWT,
   OAuth2Client,
+  ProjectIdCallback,
   UserRefreshClient,
 } from 'google-auth-library';
-import {ProjectIdCallback} from 'google-auth-library/build/src/auth/googleauth';
 
 export class AuthPlus extends GoogleAuth {
   // tslint:disable-next-line: variable-name

--- a/src/authplus.ts
+++ b/src/authplus.ts
@@ -31,7 +31,7 @@ export class AuthPlus extends GoogleAuth {
   // tslint:disable-next-line: variable-name
   GoogleAuth = GoogleAuth;
 
-  private _cachedAuth: GoogleAuth | null = null;
+  private _cachedAuth?: GoogleAuth;
 
   /**
    * Override getClient(), memoizing an instance of auth for


### PR DESCRIPTION
BREAKING CHANGE: pulls in [breaking API changes in google-auth-library](https://github.com/googleapis/google-auth-library-nodejs/blob/master/CHANGELOG.md#500-2019-07-23). `getProjectId()` and `getProjectId()` have been modified to make the impact of these changes less noticeable on the legacy googleapis module (`getClient()` is idempotent, but `getProjectId()` will use the last configuration).

At the end of the day, this allows us to avoid updating `cloud.google.com` and a a large number of auto generated samples that follow this format (not to mention stack overflow):

```js
     * function authorize(callback) {
     *   google.auth.getClient({
     *     scopes: ['https://www.googleapis.com/auth/cloud-platform']
     *   }).then(client => {
     *     callback(client);
     *   }).catch(err => {
     *     console.error('authentication failed: ', err);
     *   });
     * }
```

I'm hoping this will give us the best of both worlds:

* where gRPC clients move towards the fully idempotent API (along with clients like PubSub).
* documentation in googleapis can be updated to teach the new API surface, _however_.
* we avoid breaking gobs of legacy code floating around a variety of tutorials.