### PR TITLE
fix: allow for resource url parameter

### DIFF
--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -96,7 +96,7 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
    * In a previous version of this API, the request body was stuffed in a field
    * named `resource`.  This caused lots of problems, because it's not uncommon
    * to have an actual named parameter required which is also named `resource`.
-   * This mean that users would have to use `resource_` in those cases, which
+   * This meant that users would have to use `resource_` in those cases, which
    * pretty much nobody figures out on their own. The request body is now
    * documented as being in the `requestBody` property, but we also need to keep
    * using `resource` for reasons of back-compat. Cases that need to be covered
@@ -106,8 +106,14 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
    * - user provides just a `requestBody`
    * - user provides both a `requestBody` and a `resource`
    */
-  const resource = params.requestBody ? params.requestBody : params.resource;
-  if (!params.requestBody && params.resource) {
+  let resource = params.requestBody;
+  if (
+    !params.requestBody &&
+    params.resource &&
+    (!parameters.requiredParams.includes('resource') ||
+      typeof params.resource !== 'string')
+  ) {
+    resource = params.resource;
     delete params.resource;
   }
   delete params.requestBody;

--- a/test/test.apirequest.ts
+++ b/test/test.apirequest.ts
@@ -118,6 +118,95 @@ describe('createAPIRequest', () => {
       assert(result);
     });
 
+    it('should not populate resource parameter in URL, if not required parameter', async () => {
+      const scope = nock(url)
+        .post('/')
+        .reply(200, fakeResponse);
+      const result = await createAPIRequest<FakeParams>({
+        options: {
+          url,
+          method: 'POST',
+        },
+        params: {
+          resource: {
+            foo: 'bar',
+          },
+        },
+        requiredParams: [],
+        pathParams: [],
+        context: fakeContext,
+      });
+      scope.done();
+      assert.strictEqual(result.data, fakeResponse as {});
+      assert(result);
+    });
+
+    it('should not populate resource parameter in URL, if it is an object', async () => {
+      const scope = nock(url)
+        .post('/')
+        .reply(200, fakeResponse);
+      try {
+        const result = await createAPIRequest<FakeParams>({
+          options: {
+            url,
+            method: 'POST',
+          },
+          params: {
+            resource: {
+              foo: 'bar',
+            },
+          },
+          requiredParams: ['resource'],
+          pathParams: [],
+          context: fakeContext,
+        });
+      } catch (err) {
+        assert.match(err.message, /Missing required parameters: resource/);
+      }
+    });
+
+    it('should not populate resource parameter in URL, if it is an object', async () => {
+      const scope = nock(url)
+        .post('/')
+        .reply(200, fakeResponse);
+      try {
+        const result = await createAPIRequest<FakeParams>({
+          options: {
+            url,
+            method: 'POST',
+          },
+          params: {
+            resource: {
+              foo: 'bar',
+            },
+          },
+          requiredParams: ['resource'],
+          pathParams: [],
+          context: fakeContext,
+        });
+      } catch (err) {
+        assert.match(err.message, /Missing required parameters: resource/);
+      }
+    });
+
+    it('should  populate resource parameter in URL, if it is required', async () => {
+      const scope = nock(`${url}`)
+        .get(`/?resource=blerg`)
+        .reply(200, fakeResponse);
+      const result = await createAPIRequest<FakeParams>({
+        options: {url},
+        params: {
+          resource: 'blerg',
+        },
+        requiredParams: ['resource'],
+        pathParams: [],
+        context: fakeContext,
+      });
+      scope.done();
+      assert.strictEqual(result.data, fakeResponse as {});
+      assert(result);
+    });
+
     it('should include directives in the user agent', async () => {
       const scope = nock(url)
         .get('/')

--- a/test/test.apirequest.ts
+++ b/test/test.apirequest.ts
@@ -189,7 +189,7 @@ describe('createAPIRequest', () => {
       }
     });
 
-    it('should  populate resource parameter in URL, if it is required', async () => {
+    it('should populate resource parameter in URL, if it is required', async () => {
       const scope = nock(`${url}`)
         .get(`/?resource=blerg`)
         .reply(200, fakeResponse);


### PR DESCRIPTION
Some APIs expect a string URL parameter `resource` to be set, this interferes with our legacy API which allows a `resource` object to be passed rather than a `requestBody`, this PR adds logic to differentiate between the two behaviors.

fixes https://github.com/googleapis/google-api-nodejs-client/issues/1425
