### PR TITLE
chore: replace `qs` module and its .d.ts dependy with `query-string` …

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/mv": "^2.1.0",
     "@types/ncp": "^2.0.1",
     "@types/nock": "^10.0.3",
-    "@types/qs": "^6.5.3",
     "@types/tmp": "0.1.0",
     "@types/url-template": "^2.0.28",
     "@types/uuid": "^3.4.4",
@@ -74,7 +73,7 @@
     "extend": "^3.0.2",
     "gaxios": "^2.0.1",
     "google-auth-library": "^5.6.1",
-    "qs": "^6.7.0",
+    "query-string": "^6.9.0",
     "url-template": "^2.0.8",
     "uuid": "^3.3.2"
   },

--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -14,7 +14,7 @@
 
 import {GaxiosPromise, Headers} from 'gaxios';
 import {DefaultTransporter, OAuth2Client} from 'google-auth-library';
-import * as qs from 'qs';
+import {stringify} from 'query-string';
 import * as stream from 'stream';
 import * as urlTemplate from 'url-template';
 import * as uuid from 'uuid';
@@ -194,7 +194,7 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
   // This serializer also encodes spaces in the querystring as `%20`,
   // whereas the default serializer in gaxios encodes to a `+`.
   options.paramsSerializer = params => {
-    return qs.stringify(params, {arrayFormat: 'repeat'});
+    return stringify(params);
   };
 
   // delete path parameters from the params object so they do not end up in

--- a/test/.mocharc.json
+++ b/test/.mocharc.json
@@ -1,0 +1,6 @@
+{
+  "intelli-espower-loader": true,
+  "require": ["source-map-support/register"],
+  "throw-deprecation": true,
+  "timeout": 10000
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,0 @@
---require intelli-espower-loader
---require source-map-support/register
---throw-deprecation
---timeout 10000


### PR DESCRIPTION
…and clear mocha deprecation warning

The module replacement has nothing agaisnt the `qs` module, it is
just a proposal to reduce bundle and dependencies number,
while the `query-string` has a more clear api for the desired
effect.
Removing mocha's deprecation warning was just a "while i was here"
thing.
