### PR TITLE
feat: multipart option can now be set to provide hint that API endpoint supports multi-part uploads 

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -46,7 +46,7 @@ export interface GlobalOptions extends MethodOptions {
 export interface MethodOptions extends GaxiosOptions {
   rootUrl?: string;
   userAgentDirectives?: UserAgentDirective[];
-  uploadType?: string;
+  multipart?: boolean;
 }
 
 /**

--- a/src/api.ts
+++ b/src/api.ts
@@ -46,6 +46,7 @@ export interface GlobalOptions extends MethodOptions {
 export interface MethodOptions extends GaxiosOptions {
   rootUrl?: string;
   userAgentDirectives?: UserAgentDirective[];
+  uploadType?: string;
 }
 
 /**

--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -228,7 +228,7 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
 
   if (parameters.mediaUrl && media.body) {
     options.url = parameters.mediaUrl;
-    if (resource || parameters.options.uploadType === 'multipart') {
+    if (resource || parameters.options.multipart === true) {
       // gaxios doesn't support multipart/related uploads, so it has to
       // be implemented here.
       params.uploadType = 'multipart';

--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -240,7 +240,7 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
         },
       ];
       // There are cases where a multi-part upload may not have a resource,
-      // e.g., when an RPC like youtube.thumbnails sets the uploadType field:
+      // e.g., when the RPC youtube.thumbnails sets a video's thumbnail image.
       if (resource) {
         multipart.unshift({
           'Content-Type': 'application/json',

--- a/test/test.apirequest.ts
+++ b/test/test.apirequest.ts
@@ -366,7 +366,7 @@ describe('createAPIRequest', () => {
       assert.strictEqual(totalBytesSent, totalBytesReceived);
     });
 
-    it('should pass all chunks, when uploadType set to multipart', async () => {
+    it('should pass all chunks, when multipart=true', async () => {
       let totalBytesSent = 0;
       let totalBytesReceived = 0;
       const requestBody = {};
@@ -395,7 +395,7 @@ describe('createAPIRequest', () => {
         },
       };
       await createAPIRequest<FakeParams>({
-        options: {url, uploadType: 'multipart'},
+        options: {url, multipart: true},
         params: {
           media,
           auth,

--- a/test/test.apirequest.ts
+++ b/test/test.apirequest.ts
@@ -326,13 +326,10 @@ describe('createAPIRequest', () => {
   });
 
   describe('mock stream', () => {
-    let totalBytesSent: number;
-    let totalBytesReceived = 0;
-    const requestBody = {};
-    beforeEach(() => {
-      totalBytesReceived = 0;
-    });
     it('should pass all chunks', async () => {
+      let totalBytesSent = 0;
+      let totalBytesReceived = 0;
+      const requestBody = {};
       const fStream = new FakeReadable();
       fStream.on('progress', (currentBytesSent: number) => {
         totalBytesSent = currentBytesSent;
@@ -370,6 +367,9 @@ describe('createAPIRequest', () => {
     });
 
     it('should pass all chunks, when uploadType set to multipart', async () => {
+      let totalBytesSent = 0;
+      let totalBytesReceived = 0;
+      const requestBody = {};
       const fStream = new FakeReadable();
       fStream.on('progress', (currentBytesSent: number) => {
         totalBytesSent = currentBytesSent;


### PR DESCRIPTION
There was an assumption being made that a `requestBody` would always be set, containing meta information about the resource being uploaded, when a multipart upload is being performed.

This is not the case for `youtube.thumbnails()`, which sets only the ID of a video that a thumbnail is being set for. This PR allows the `uploadType` to explicitly be set for these edge-cases.

fixes: https://github.com/googleapis/google-api-nodejs-client/issues/1820