### PR TITLE
fix: solve multipart uploads in browser context

### DIFF
--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -229,52 +229,79 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
   if (parameters.mediaUrl && media.body) {
     options.url = parameters.mediaUrl;
     if (resource) {
-      // gaxios doesn't support multipart/related uploads, so it has to
-      // be implemented here.
-      params.uploadType = 'multipart';
-      const multipart = [
-        {'Content-Type': 'application/json', body: JSON.stringify(resource)},
-        {
-          'Content-Type':
-            media.mimeType || (resource && resource.mimeType) || defaultMime,
-          body: media.body, // can be a readable stream or raw string!
-        },
-      ];
-      const boundary = uuid.v4();
-      const finale = `--${boundary}--`;
-      const rStream = new stream.PassThrough({
-        flush(callback) {
-          this.push('\r\n');
-          this.push(finale);
-          callback();
-        },
-      });
-      const pStream = new ProgressStream();
-      const isStream = isReadableStream(multipart[1].body);
-      headers['Content-Type'] = `multipart/related; boundary=${boundary}`;
-      for (const part of multipart) {
-        const preamble = `--${boundary}\r\nContent-Type: ${part['Content-Type']}\r\n\r\n`;
-        rStream.push(preamble);
-        if (typeof part.body === 'string') {
-          rStream.push(part.body);
-          rStream.push('\r\n');
-        } else {
-          // Gaxios does not natively support onUploadProgress in node.js.
-          // Pipe through the pStream first to read the number of bytes read
-          // for the purpose of tracking progress.
-          pStream.on('progress', bytesRead => {
-            if (options.onUploadProgress) {
-              options.onUploadProgress({bytesRead});
-            }
-          });
-          part.body.pipe(pStream).pipe(rStream);
+      let multipart;
+      if (!isBrowser()) {
+        // gaxios doesn't support multipart/related uploads, so it has to
+        // be implemented here.
+        params.uploadType = 'multipart';
+        multipart = [
+          {'Content-Type': 'application/json', body: JSON.stringify(resource)},
+          {
+            'Content-Type':
+              media.mimeType || (resource && resource.mimeType) || defaultMime,
+            body: media.body, // can be a readable stream or raw string!
+          },
+        ];
+        const boundary = uuid.v4();
+        const finale = `--${boundary}--`;
+        const rStream = new stream.PassThrough({
+          flush(callback) {
+            this.push('\r\n');
+            this.push(finale);
+            callback();
+          },
+        });
+        const pStream = new ProgressStream();
+        const isStream = isReadableStream(multipart[1].body);
+        headers['Content-Type'] = `multipart/related; boundary=${boundary}`;
+        for (const part of multipart) {
+          const preamble = `--${boundary}\r\nContent-Type: ${part['Content-Type']}\r\n\r\n`;
+          rStream.push(preamble);
+          if (typeof part.body === 'string') {
+            rStream.push(part.body);
+            rStream.push('\r\n');
+          } else {
+            // Gaxios does not natively support onUploadProgress in node.js.
+            // Pipe through the pStream first to read the number of bytes read
+            // for the purpose of tracking progress.
+            pStream.on('progress', bytesRead => {
+              if (options.onUploadProgress) {
+                options.onUploadProgress({bytesRead});
+              }
+            });
+            part.body.pipe(pStream).pipe(rStream);
+          }
         }
+        if (!isStream) {
+          rStream.push(finale);
+          rStream.push(null);
+        }
+        options.data = rStream;
+      } else {
+        params.uploadType = 'multipart';
+        multipart = [
+          {'Content-Type': 'application/json', body: JSON.stringify(resource)},
+          {
+            'Content-Type': 'text/plain',
+            body: media.body.toString(),
+          },
+        ];
+        const boundary = uuid.v4();
+        const finale = `--${boundary}--`;
+        headers['Content-Type'] = `multipart/related; boundary=${boundary}`;
+
+        let content = '';
+        for (const part of multipart) {
+          const preamble = `--${boundary}\r\nContent-Type: ${part['Content-Type']}\r\n\r\n`;
+          content += preamble;
+          if (typeof part.body === 'string') {
+            content += part.body;
+            content += '\r\n';
+          }
+        }
+        content += finale;
+        options.data = content;
       }
-      if (!isStream) {
-        rStream.push(finale);
-        rStream.push(null);
-      }
-      options.data = rStream;
     } else {
       params.uploadType = 'media';
       Object.assign(headers, {'Content-Type': media.mimeType || defaultMime});


### PR DESCRIPTION
This PR uses @bcoe's [test](https://www.google.com/url?sa=j&url=https%3A%2F%2Fgithub.com%2Fgoogleapis%2Fgaxios%2Fpull%2F286&uct=1579725212&usg=hf_07Wbv_A9PibMkJPD8nKjnf3g.&source=chat) to stub out a solution for this [issue](https://github.com/googleapis/google-api-nodejs-client/issues/1878) in nodejs-client. Currently, there is an issue when uploading files in the browser context through multipart uploads, because the content is uploaded as a stream. This PR changes the logic in browser settings to not use streams.