### PR TITLE
fix: ensure options changes do not leak upstream

### DIFF
--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -34,7 +34,7 @@ const pkg = require('../../package.json');
 
 interface Multipart {
   'Content-Type': string;
-  body: any;
+  body: string | stream.Readable;
 }
 function isReadableStream(obj: stream.Readable | string) {
   return obj instanceof stream.Readable && typeof obj._read === 'function';
@@ -78,48 +78,29 @@ export function createAPIRequest<T>(
 }
 
 async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
-  const options = Object.assign({}, parameters.options);
+  // Combine the GaxiosOptions options passed with this specific
+  // API call witht the global options configured at the API Context
+  // level, or at the global level.
+  const options = extend(
+    true,
+    {},
+    parameters.context.google?._options || {},
+    parameters.context._options || {},
+    parameters.options
+  );
 
-  // Create a new params object so it can no longer be modified from outside
-  // code Also support global and per-client params, but allow them to be
-  // overriden per-request
-  const globalParams =
-    parameters.context.google &&
-    parameters.context.google._options &&
-    parameters.context.google._options.params
-      ? parameters.context.google._options.params
-      : {};
-  const clientParams =
-    parameters.context &&
-    parameters.context._options &&
-    parameters.context._options.params
-      ? parameters.context._options.params
-      : {};
-  const params = Object.assign(
+  const params = extend(
+    true,
     {}, // New base object
-    globalParams, // Global params
-    clientParams, // Per-client params
+    options.params, // Combined global/per-api params
     parameters.params // API call params
   );
 
   // Check for user specified user agents at all levels of config
-  const userAgentGlobal =
-    parameters.context.google &&
-    parameters.context.google._options &&
-    parameters.context.google._options.userAgentDirectives
-      ? parameters.context.google._options.userAgentDirectives
-      : [];
-  const userAgentClient =
-    parameters.context &&
-    parameters.context._options &&
-    parameters.context._options.userAgentDirectives
-      ? parameters.context._options.userAgentDirectives
-      : [];
   const userAgentDirectives: UserAgentDirective[] =
     Object.assign(
       [],
-      userAgentGlobal,
-      userAgentClient,
+      options.userAgentDirectives,
       parameters.options.userAgentDirectives
     ) || [];
 
@@ -151,12 +132,7 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
   }
   delete params.requestBody;
 
-  let authClient =
-    params.auth ||
-    parameters.context._options.auth ||
-    (parameters.context.google
-      ? parameters.context.google._options.auth
-      : null);
+  let authClient = params.auth || options.auth;
 
   const defaultMime =
     typeof media.body === 'string' ? 'text/plain' : 'application/octet-stream';
@@ -211,18 +187,8 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
     return qs.stringify(params, {arrayFormat: 'repeat'});
   };
 
-  // delete path parameters from the params object so they do not end up in
-  // query
-  parameters.pathParams.forEach(param => {
-    delete params[param];
-    if (
-      parameters.context &&
-      parameters.context._options &&
-      parameters.context._options.params
-    ) {
-      delete parameters.context._options.params[param];
-    }
-  });
+  // delete path params from the params object so they do not end up in query
+  parameters.pathParams.forEach(param => delete params[param]);
 
   // if authClient is actually a string, use it as an API KEY
   if (typeof authClient === 'string') {
@@ -346,27 +312,16 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
 
   // Retry by default
   options.retry = options.retry === undefined ? true : options.retry;
-
-  // Combine the GaxiosOptions options passed with this specific
-  // API call witht the global options configured at the API Context
-  // level, or at the global level.
-  const mergedOptions = extend(
-    true,
-    {},
-    parameters.context.google ? parameters.context.google._options : {},
-    parameters.context._options,
-    options
-  );
-  delete mergedOptions.auth; // is overridden by our auth code
+  delete options.auth; // is overridden by our auth code
 
   // Perform the HTTP request.  NOTE: this function used to return a
   // mikeal/request object. Since the transition to Axios, the method is
   // now void.  This may be a source of confusion for users upgrading from
   // version 24.0 -> 25.0 or up.
   if (authClient && typeof authClient === 'object') {
-    return (authClient as OAuth2Client).request<T>(mergedOptions);
+    return (authClient as OAuth2Client).request<T>(options);
   } else {
-    return new DefaultTransporter().request<T>(mergedOptions);
+    return new DefaultTransporter().request<T>(options);
   }
 }
 

--- a/test/test.apirequest.ts
+++ b/test/test.apirequest.ts
@@ -412,5 +412,31 @@ describe('createAPIRequest', () => {
       const expectedUrl = `${url}/projects/${projectId}`;
       assert.strictEqual(res.config.url, expectedUrl);
     });
+
+    it('should persist path params set at the API level', async () => {
+      const optUrl = `${url}/projects/{projectId}`;
+      const projectId = 'not-a-project';
+      const path = `/projects/${projectId}`;
+      const scope = nock(url).get(path).twice().reply(200);
+      const params = {
+        options: {url: optUrl},
+        params: {},
+        requiredParams: [],
+        pathParams: ['projectId'],
+        context: {
+          _options: {
+            params: {
+              projectId,
+            },
+          },
+        },
+      };
+      const expectedUrl = `${url}/projects/${projectId}`;
+      const res1 = await createAPIRequest<FakeParams>(params);
+      assert.strictEqual(res1.config.url, expectedUrl);
+      const res2 = await createAPIRequest<FakeParams>(params);
+      assert.strictEqual(res2.config.url, expectedUrl);
+      scope.done();
+    });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-api-nodejs-client/issues/2029.  This is a kind of scary change.  The tests pass here, and after an `npm link` with `googleapis`, the tests all pass over there now too.  @bcoe @alexander-fenster I could really use a careful set of eyes on these changes.  