### PR TITLE
feat: add experimental http/2 support

### DIFF
--- a/benchmark/bench.ts
+++ b/benchmark/bench.ts
@@ -1,0 +1,87 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {GoogleAuth, createAPIRequest, JWT} from '../src';
+import * as sinon from 'sinon';
+
+/**
+ * Make sure that making batch requests with HTTP/2 is actually faster.
+ */
+
+async function main() {
+  const sampleSize = 50;
+  const http1Results: Promise<number>[] = [];
+  for (let i = 0; i < sampleSize; i++) {
+    http1Results.push(makeHttp1Request());
+  }
+  const http1RealResults = await Promise.all(http1Results);
+  console.log(http1RealResults);
+  const avg1 =
+    http1RealResults.reduce((acc, curr) => (acc += curr)) / sampleSize;
+  console.log(`HTTP 1.1 Avg: ${avg1}`);
+  const http2Results: Promise<number>[] = [];
+  for (let i = 0; i < 50; i++) {
+    http2Results.push(makeHttp2Request());
+  }
+  const http2RealResults = await Promise.all(http2Results);
+  console.log(http2RealResults);
+  const avg2 =
+    http2RealResults.reduce((acc, curr) => (acc += curr)) / sampleSize;
+  console.log(`HTTP 2 Avg: ${avg2}`);
+}
+
+async function makeHttp2Request() {
+  const sandbox = sinon.createSandbox();
+  const url = 'https://www.googleapis.com/discovery/v1/apis/';
+  const auth = new GoogleAuth();
+  sandbox.stub(auth, 'getRequestHeaders').resolves({});
+  const startTime = Date.now();
+  await createAPIRequest<{}>({
+    options: {url, http2: true},
+    params: {},
+    requiredParams: [],
+    pathParams: [],
+    context: {
+      _options: {
+        auth,
+      },
+    },
+  });
+  const endTime = Date.now();
+  return endTime - startTime;
+}
+
+async function makeHttp1Request() {
+  const sandbox = sinon.createSandbox();
+  const url = 'https://www.googleapis.com/discovery/v1/apis/';
+  const auth = new JWT();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sandbox.stub(auth as any, 'getRequestMetadataAsync').resolves({});
+  const startTime = Date.now();
+  await createAPIRequest<{}>({
+    options: {url},
+    params: {},
+    requiredParams: [],
+    pathParams: [],
+    context: {
+      _options: {
+        auth,
+      },
+    },
+  });
+  const endTime = Date.now();
+  return endTime - startTime;
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "!build/src/**/*.map"
   ],
   "scripts": {
+    "prebenchmark": "npm run compile",
+    "benchmark": "node build/benchmark/bench.js",
     "compile": "tsc -p .",
     "test": "c8 mocha build/test",
-    "system-test": "mocha build/system-test",
+    "system-test": "c8 mocha build/system-test",
     "presystem-test": "npm run compile",
     "fix": "gts fix",
     "prepare": "npm run compile",
@@ -47,6 +49,7 @@
     "@types/mv": "^2.1.0",
     "@types/ncp": "^2.0.1",
     "@types/nock": "^10.0.3",
+    "@types/proxyquire": "^1.3.28",
     "@types/qs": "^6.5.3",
     "@types/sinon": "^9.0.4",
     "@types/tmp": "0.2.0",
@@ -56,6 +59,7 @@
     "codecov": "^3.5.0",
     "execa": "^4.0.0",
     "gts": "^2.0.0",
+    "http2spy": "^2.0.0",
     "is-docker": "^2.0.0",
     "karma": "^5.0.0",
     "karma-chrome-launcher": "^3.0.0",
@@ -72,6 +76,7 @@
     "nock": "^12.0.0",
     "null-loader": "^4.0.0",
     "puppeteer": "^4.0.0",
+    "proxyquire": "^2.1.3",
     "sinon": "^9.0.2",
     "tmp": "^0.2.0",
     "ts-loader": "^7.0.0",
@@ -80,6 +85,6 @@
     "webpack-cli": "^3.3.5"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=10.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "benchmark": "node build/benchmark/bench.js",
     "compile": "tsc -p .",
     "test": "c8 mocha build/test",
-    "system-test": "c8 mocha build/system-test",
+    "system-test": "c8 mocha build/system-test --timeout 600000",
     "presystem-test": "npm run compile",
     "fix": "gts fix",
     "prepare": "npm run compile",

--- a/src/api.ts
+++ b/src/api.ts
@@ -45,6 +45,7 @@ export interface GlobalOptions extends MethodOptions {
 
 export interface MethodOptions extends GaxiosOptions {
   rootUrl?: string;
+  http2?: boolean;
   userAgentDirectives?: UserAgentDirective[];
 }
 

--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -30,7 +30,7 @@ import resolve = require('url');
 const pkg = require('../../package.json');
 
 interface Multipart {
-  'Content-Type': string;
+  'content-type': string;
   body: string | stream.Readable;
 }
 
@@ -207,9 +207,9 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
     });
     const pStream = new ProgressStream();
     const isStream = isReadableStream(multipart[1].body);
-    headers['Content-Type'] = `multipart/related; boundary=${boundary}`;
+    headers['content-type'] = `multipart/related; boundary=${boundary}`;
     for (const part of multipart) {
-      const preamble = `--${boundary}\r\nContent-Type: ${part['Content-Type']}\r\n\r\n`;
+      const preamble = `--${boundary}\r\ncontent-type: ${part['content-type']}\r\n\r\n`;
       rStream.push(preamble);
       if (typeof part.body === 'string') {
         rStream.push(part.body);
@@ -236,11 +236,11 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
   function browserMultipartUpload(multipart: Multipart[]) {
     const boundary = uuid.v4();
     const finale = `--${boundary}--`;
-    headers['Content-Type'] = `multipart/related; boundary=${boundary}`;
+    headers['content-type'] = `multipart/related; boundary=${boundary}`;
 
     let content = '';
     for (const part of multipart) {
-      const preamble = `--${boundary}\r\nContent-Type: ${part['Content-Type']}\r\n\r\n`;
+      const preamble = `--${boundary}\r\ncontent-type: ${part['content-type']}\r\n\r\n`;
       content += preamble;
       if (typeof part.body === 'string') {
         content += part.body;
@@ -256,9 +256,9 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
     if (resource) {
       params.uploadType = 'multipart';
       const multipart = [
-        {'Content-Type': 'application/json', body: JSON.stringify(resource)},
+        {'content-type': 'application/json', body: JSON.stringify(resource)},
         {
-          'Content-Type':
+          'content-type':
             media.mimeType || (resource && resource.mimeType) || defaultMime,
           body: media.body,
         },
@@ -272,7 +272,7 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
       }
     } else {
       params.uploadType = 'media';
-      Object.assign(headers, {'Content-Type': media.mimeType || defaultMime});
+      Object.assign(headers, {'content-type': media.mimeType || defaultMime});
       options.data = media.body;
     }
   } else {

--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -22,6 +22,7 @@ import * as extend from 'extend';
 import {APIRequestParams, BodyResponseCallback} from './api';
 import {isBrowser} from './isbrowser';
 import {SchemaParameters} from './schema';
+import * as h2 from './http2';
 
 import resolve = require('url');
 
@@ -317,7 +318,14 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
   // now void.  This may be a source of confusion for users upgrading from
   // version 24.0 -> 25.0 or up.
   if (authClient && typeof authClient === 'object') {
-    return (authClient as OAuth2Client).request<T>(options);
+    if (options.http2) {
+      const authHeaders = await authClient.getRequestHeaders(options.url);
+      const mooOpts = Object.assign({}, options);
+      mooOpts.headers = Object.assign(mooOpts.headers, authHeaders);
+      return h2.request<T>(mooOpts);
+    } else {
+      return (authClient as OAuth2Client).request<T>(options);
+    }
   } else {
     return new DefaultTransporter().request<T>(options);
   }

--- a/src/http2.ts
+++ b/src/http2.ts
@@ -1,0 +1,227 @@
+// Copyright 2019, Google, LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as http2 from 'http2';
+import * as zlib from 'zlib';
+import {URL} from 'url';
+import * as qs from 'qs';
+import * as extend from 'extend';
+import {Stream, Readable} from 'stream';
+import * as util from 'util';
+import * as process from 'process';
+import {GaxiosResponse, GaxiosOptions} from 'gaxios';
+import {GaxiosXMLHttpRequest, GaxiosError} from 'gaxios/build/src/common';
+
+const {
+  HTTP2_HEADER_CONTENT_ENCODING,
+  HTTP2_HEADER_CONTENT_TYPE,
+  HTTP2_HEADER_METHOD,
+  HTTP2_HEADER_PATH,
+  HTTP2_HEADER_STATUS,
+} = http2.constants;
+
+const DEBUG = !!process.env.HTTP2_DEBUG;
+
+/**
+ * Reference to the ClientHttp2Session and a timeout handler.
+ * @private
+ */
+export interface SessionData {
+  client: http2.ClientHttp2Session;
+  timeoutHandle?: NodeJS.Timer;
+}
+
+/**
+ * List of sessions current in use.
+ * @private
+ */
+export const sessions: {[index: string]: SessionData} = {};
+let warned = false;
+
+/**
+ * Public method to make an http2 request.
+ * @param config - Request options.
+ */
+export async function request<T>(
+  config: GaxiosOptions
+): Promise<GaxiosResponse<T>> {
+  // Make sure users know this API is unstable
+  if (!warned) {
+    const message = `
+      The HTTP/2 API in googleapis is unstable! This is an early implementation
+      that should not be used in production.  It may change in unpredictable
+      ways. Please only use this for experimentation.
+    `;
+    process.emitWarning(message, 'GOOG_HTTP2');
+    warned = true;
+  }
+
+  const opts = extend(true, {}, config);
+  opts.validateStatus = opts.validateStatus || validateStatus;
+  opts.responseType = opts.responseType || 'json';
+
+  const url = new URL(opts.url!);
+
+  // Check for an existing session to this host, or go create a new one.
+  const session = _getClient(url.host);
+
+  // Since we're using this session, clear the timeout handle to ensure
+  // it stays in memory and connected for a while further.
+  if (session.timeoutHandle !== undefined) {
+    clearTimeout(session.timeoutHandle);
+  }
+
+  // Assemble the querystring based on config.params.  We're using the
+  // `qs` module to make life a little easier.
+  let pathWithQs = url.pathname;
+  if (config.params) {
+    const q = qs.stringify(opts.params);
+    pathWithQs += `?${q}`;
+  }
+
+  // Assemble the headers based on basic HTTP2 primitives (path, method) and
+  // custom headers sent from the consumer.  Note: I am using `Object.assign`
+  // here making the assumption these objects are not deep.  If it turns out
+  // they are, we may need to use the `extend` npm module for deep cloning.
+  const headers = Object.assign({}, opts.headers, {
+    [HTTP2_HEADER_PATH]: pathWithQs,
+    [HTTP2_HEADER_METHOD]: config.method || 'GET',
+    [HTTP2_HEADER_CONTENT_TYPE]: 'application/json',
+  });
+
+  const req = session.client.request(headers);
+  const chunks: Buffer[] = [];
+  const res: GaxiosResponse<T> = {
+    config,
+    request: (req as {}) as GaxiosXMLHttpRequest,
+    headers: [],
+    status: 0,
+    data: {} as T,
+    statusText: '',
+  };
+
+  return new Promise((resolve, reject) => {
+    req
+      .on('data', d => chunks.push(d))
+      .on('response', headers => {
+        res.headers = headers;
+        res.status = Number(headers[HTTP2_HEADER_STATUS]);
+        let stream: Readable = req;
+        if (headers[HTTP2_HEADER_CONTENT_ENCODING] === 'gzip') {
+          stream = req.pipe(zlib.createGunzip());
+        }
+        if (opts.responseType === 'stream') {
+          res.data = (stream as {}) as T;
+          resolve(res);
+          return;
+        }
+      })
+      .on('error', e => {
+        reject(e);
+        return;
+      })
+      .on('end', () => {
+        const allChunks = Buffer.concat(chunks);
+        // TODO: Currently, this code is double buffering responses by storing
+        // the entire buffer contents in memory, and then piping that through
+        // gunzipSync. This should be changed to pipe the data towards a stream,
+        // and to not use the `Sync` method.
+        let data = '';
+        if (res.headers[HTTP2_HEADER_CONTENT_ENCODING] === 'gzip') {
+          data = zlib.gunzipSync(allChunks).toString('utf8');
+        } else {
+          data = allChunks.toString('utf8');
+        }
+        res.data = JSON.parse(data);
+
+        if (!opts.validateStatus!(res.status)) {
+          let message = `Request failed with status code ${res.status}. `;
+          if (res.data && typeof res.data === 'object') {
+            message =
+              message +
+              '\n' +
+              util.inspect(res.data, {
+                depth: 5,
+              });
+          }
+          reject(new GaxiosError<T>(message, opts, res));
+        }
+        resolve(res);
+        return;
+      });
+
+    // If data was provided, write it to the request in the form of
+    // a stream, string data, or a basic object.
+    if (config.data) {
+      if (config.data instanceof Stream) {
+        config.data.pipe(req);
+      } else if (typeof config.data === 'string') {
+        const data = Buffer.from(config.data);
+        req.end(data);
+      } else if (typeof config.data === 'object') {
+        const data = JSON.stringify(config.data);
+        req.end(data);
+      }
+    }
+
+    // Create a timeout so the Http2Session will be cleaned up after
+    // a period of non-use. 500 milliseconds was chosen because it's
+    // a nice round number, and I don't know what would be a better
+    // choice. Keeping this channel open will hold a file descriptor
+    // which will prevent the process from exiting.
+    session.timeoutHandle = setTimeout(() => {
+      session.client.close(() => {
+        if (DEBUG) {
+          console.error(`Closing ${url.host}`);
+        }
+        delete sessions[url.host];
+      });
+    }, 500);
+  });
+}
+
+/**
+ * By default, throw for any non-2xx status code
+ * @param status - status code from the HTTP response
+ */
+function validateStatus(status: number) {
+  return status >= 200 && status < 300;
+}
+
+/**
+ * Obtain an existing h2 session or go create a new one.
+ * @param host - The hostname to which the session belongs.
+ */
+function _getClient(host: string): SessionData {
+  if (!sessions[host]) {
+    if (DEBUG) {
+      console.log(`Creating client for ${host}`);
+    }
+    const client = http2.connect(`https://${host}`);
+    client
+      .on('error', e => {
+        console.error(`*ERROR*: ${e}`);
+        delete sessions[host];
+      })
+      .on('goaway', (errorCode, lastStreamId) => {
+        console.error(`*GOAWAY*: ${errorCode} : ${lastStreamId}`);
+        delete sessions[host];
+      });
+    sessions[host] = {client};
+  } else {
+    if (DEBUG) {
+      console.log(`Used cached client for ${host}`);
+    }
+  }
+  return sessions[host];
+}

--- a/src/http2.ts
+++ b/src/http2.ts
@@ -1,4 +1,4 @@
-// Copyright 2019, Google, LLC.
+// Copyright 2020 Google LLC
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/system-test/fixtures/kitchen/webpack.config.js
+++ b/system-test/fixtures/kitchen/webpack.config.js
@@ -30,11 +30,12 @@ module.exports = {
     child_process: 'empty',
     fs: 'empty',
     crypto: 'empty',
+    http2: 'empty',
   },
   module: {
     rules: [
       {
-        test: /src\/crypto\/node\/crypto/,
+        test: /src\/http2/,
         use: 'null-loader',
       },
       {

--- a/system-test/test.http2.ts
+++ b/system-test/test.http2.ts
@@ -92,10 +92,7 @@ describe('http2', () => {
       pathParams: [],
       context,
     });
-    console.log(result.data);
+    assert.ok(result.data);
     assert(result.data instanceof stream.Readable);
-    for await (const d of result.data) {
-      console.log(d.toString('utf8'));
-    }
   });
 });

--- a/system-test/test.http2.ts
+++ b/system-test/test.http2.ts
@@ -97,7 +97,8 @@ describe('http2', () => {
   });
 
   it('should handle multi-part uploads', async () => {
-    const url = 'https://storage.googleapis.com/storage/v1/b/el-gato/o';
+    const projectId = await auth.getProjectId();
+    const url = `https://storage.googleapis.com/storage/v1/b/${projectId}/o`;
     const result = await createAPIRequest<FakeParams>({
       options: {
         url,
@@ -114,7 +115,7 @@ describe('http2', () => {
           body: 'Hello World',
         },
       },
-      mediaUrl: 'https://www.googleapis.com/upload/storage/v1/b/el-gato/o',
+      mediaUrl: `https://www.googleapis.com/upload/storage/v1/b/${projectId}/o`,
       requiredParams: [],
       pathParams: [],
       context,

--- a/system-test/test.http2.ts
+++ b/system-test/test.http2.ts
@@ -95,4 +95,42 @@ describe('http2', () => {
     assert.ok(result.data);
     assert(result.data instanceof stream.Readable);
   });
+
+  it('should handle multi-part uploads', async () => {
+    const url = 'https://storage.googleapis.com/storage/v1/b/el-gato/o';
+    const result = await createAPIRequest<FakeParams>({
+      options: {
+        url,
+        http2: true,
+        method: 'POST',
+      },
+      params: {
+        requestBody: {
+          name: 'Test',
+          mimeType: 'text/plain',
+        },
+        media: {
+          mimeType: 'text/plain',
+          body: 'Hello World',
+        },
+      },
+      mediaUrl: 'https://www.googleapis.com/upload/storage/v1/b/el-gato/o',
+      requiredParams: [],
+      pathParams: [],
+      context,
+    });
+    assert.ok(result.data);
+    assert.strictEqual(result.status, 200);
+    await createAPIRequest<FakeParams>({
+      options: {
+        url: url + '/Test',
+        http2: true,
+        method: 'DELETE',
+      },
+      params: {},
+      requiredParams: [],
+      pathParams: [],
+      context,
+    });
+  });
 });

--- a/system-test/test.http2.ts
+++ b/system-test/test.http2.ts
@@ -1,0 +1,101 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {describe, it, before} from 'mocha';
+import {APIRequestContext, GoogleAuth, createAPIRequest} from '../src';
+import * as stream from 'stream';
+
+interface FakeParams {
+  foo: string;
+  bar: string;
+}
+describe.only('http2', () => {
+  const auth = new GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+  });
+  let context = {
+    _options: {
+      auth,
+    },
+  } as APIRequestContext;
+
+  before(async () => {
+    const client = await auth.getClient();
+    context = {
+      _options: {
+        auth: client,
+      },
+    };
+  });
+
+  it('should create a valid HTTP/2 API request', async () => {
+    const url = 'https://storage.googleapis.com/storage/v1/b';
+    const projectId = await auth.getProjectId();
+    const result = await createAPIRequest<FakeParams>({
+      options: {url, http2: true},
+      params: {
+        project: projectId,
+      },
+      requiredParams: [],
+      pathParams: [],
+      context,
+    });
+    assert(result.data);
+  });
+
+  it('it should send data in a POST', async () => {
+    const url = 'https://translation.googleapis.com/language/translate/v2';
+    const result = await createAPIRequest<{}>({
+      options: {
+        url,
+        method: 'POST',
+        http2: true,
+      },
+      params: {
+        requestBody: {
+          q: 'hello there',
+          target: 'es',
+        },
+      },
+      requiredParams: [],
+      pathParams: [],
+      context,
+    });
+    assert(result.data);
+  });
+
+  it.only('should return a stream if asked nicely', async () => {
+    const url = 'https://storage.googleapis.com/storage/v1/b';
+    const projectId = await auth.getProjectId();
+    const result = await createAPIRequest<FakeParams>({
+      options: {
+        url,
+        http2: true,
+        responseType: 'stream',
+      },
+      params: {
+        project: projectId,
+      },
+      requiredParams: [],
+      pathParams: [],
+      context,
+    });
+    console.log(result.data);
+    assert(result.data instanceof stream.Readable);
+    for await (const d of result.data) {
+      console.log(d.toString('utf8'));
+    }
+  });
+});

--- a/system-test/test.http2.ts
+++ b/system-test/test.http2.ts
@@ -16,6 +16,7 @@ import * as assert from 'assert';
 import {describe, it, before} from 'mocha';
 import {APIRequestContext, GoogleAuth, createAPIRequest} from '../src';
 import * as stream from 'stream';
+import * as uuid from 'uuid';
 
 interface FakeParams {
   foo: string;
@@ -98,6 +99,7 @@ describe('http2', () => {
 
   it('should handle multi-part uploads', async () => {
     const projectId = await auth.getProjectId();
+    const name = uuid.v4();
     const url = `https://storage.googleapis.com/storage/v1/b/${projectId}/o`;
     const result = await createAPIRequest<FakeParams>({
       options: {
@@ -107,7 +109,7 @@ describe('http2', () => {
       },
       params: {
         requestBody: {
-          name: 'Test',
+          name,
           mimeType: 'text/plain',
         },
         media: {
@@ -124,7 +126,7 @@ describe('http2', () => {
     assert.strictEqual(result.status, 200);
     await createAPIRequest<FakeParams>({
       options: {
-        url: url + '/Test',
+        url: `${url}/${name}`,
         http2: true,
         method: 'DELETE',
       },

--- a/system-test/test.http2.ts
+++ b/system-test/test.http2.ts
@@ -21,7 +21,7 @@ interface FakeParams {
   foo: string;
   bar: string;
 }
-describe.only('http2', () => {
+describe('http2', () => {
   const auth = new GoogleAuth({
     scopes: ['https://www.googleapis.com/auth/cloud-platform'],
   });
@@ -76,7 +76,7 @@ describe.only('http2', () => {
     assert(result.data);
   });
 
-  it.only('should return a stream if asked nicely', async () => {
+  it('should return a stream if asked nicely', async () => {
     const url = 'https://storage.googleapis.com/storage/v1/b';
     const projectId = await auth.getProjectId();
     const result = await createAPIRequest<FakeParams>({

--- a/system-test/test.http2.ts
+++ b/system-test/test.http2.ts
@@ -117,7 +117,7 @@ describe('http2', () => {
           body: 'Hello World',
         },
       },
-      mediaUrl: `https://www.googleapis.com/upload/storage/v1/b/${projectId}/o`,
+      mediaUrl: `https://storage.googleapis.com/upload/storage/v1/b/${projectId}/o`,
       requiredParams: [],
       pathParams: [],
       context,

--- a/system-test/test.kitchen.ts
+++ b/system-test/test.kitchen.ts
@@ -35,8 +35,7 @@ describe('pack and install', () => {
    * Create a staging directory with temp fixtures used to test on a fresh
    * application.
    */
-  before('should be able to use the d.ts', async function () {
-    this.timeout(40000);
+  before('should be able to use the d.ts', async () => {
     console.log(`${__filename} staging area: ${stagingPath}`);
     await execa('npm', ['pack'], {stdio: 'inherit'});
     const tarball = `${pkg.name}-${pkg.version}.tgz`;
@@ -53,7 +52,7 @@ describe('pack and install', () => {
     const bundle = path.join(stagingPath, 'dist', 'bundle.min.js');
     const stat = fs.statSync(bundle);
     assert(stat.size < 256 * 1024);
-  }).timeout(20000);
+  });
 
   /**
    * CLEAN UP - remove the staging directory when done.

--- a/test/test.apirequest.ts
+++ b/test/test.apirequest.ts
@@ -326,7 +326,7 @@ describe('createAPIRequest', () => {
     };
     const auth = {
       request: (opts: GlobalOptions & MethodOptions) => {
-        const contentType = opts.headers!['Content-Type'];
+        const contentType = opts.headers!['content-type'];
         const boundary = `--${contentType.substring(
           contentType.indexOf('boundary=') + 9
         )}--`;

--- a/test/test.http2.ts
+++ b/test/test.http2.ts
@@ -43,7 +43,7 @@ class FakeClient extends EventEmitter {
   };
 }
 
-describe.only('http2', () => {
+describe('http2', () => {
   const auth = new GoogleAuth({
     scopes: ['https://www.googleapis.com/auth/cloud-platform'],
   });

--- a/test/test.http2.ts
+++ b/test/test.http2.ts
@@ -41,6 +41,7 @@ class FakeClient extends EventEmitter {
   close = (callback: Function) => {
     callback();
   };
+  destroy = () => {};
 }
 
 describe('http2', () => {
@@ -164,7 +165,7 @@ describe('http2', () => {
     requestStream.push(Buffer.from('{}'));
     requestStream.push(null);
     await resPromise;
-    http2.sessions['example.com'].client.emit('error', new Error('😱'));
+    http2.sessions['example.com'].session.emit('error', new Error('😱'));
     assert.strictEqual(Object.keys(http2.sessions).length, 0);
   });
 
@@ -176,7 +177,7 @@ describe('http2', () => {
     requestStream.push(Buffer.from('{}'));
     requestStream.push(null);
     await resPromise;
-    http2.sessions['example.com'].client.emit('goaway');
+    http2.sessions['example.com'].session.emit('goaway');
     assert.strictEqual(Object.keys(http2.sessions).length, 0);
   });
 

--- a/test/test.http2.ts
+++ b/test/test.http2.ts
@@ -1,0 +1,224 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as coreHttp2 from 'http2';
+import {describe, it, before, beforeEach} from 'mocha';
+import {gzipSync} from 'zlib';
+import * as proxyquire from 'proxyquire';
+import * as sinon from 'sinon';
+import {Readable} from 'stream';
+import {EventEmitter} from 'events';
+import {GaxiosResponse} from 'gaxios';
+import * as http2Types from '../src/http2';
+
+import {GoogleAuth} from '../src';
+
+const {
+  HTTP2_HEADER_CONTENT_TYPE,
+  HTTP2_HEADER_METHOD,
+  HTTP2_HEADER_PATH,
+  HTTP2_HEADER_STATUS,
+  HTTP2_HEADER_CONTENT_ENCODING,
+} = coreHttp2.constants;
+
+class FakeClient extends EventEmitter {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  request = (headers: coreHttp2.OutgoingHttpHeaders) => {
+    return new EventEmitter();
+  };
+  close = (callback: Function) => {
+    callback();
+  };
+}
+
+describe.only('http2', () => {
+  const auth = new GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+  });
+
+  // explicitly setting this on `sinon` and not the `sandbox` so this stub
+  // persists across test runs.
+  sinon.stub(auth, 'request').resolves({
+    data: {},
+  } as GaxiosResponse<{}>);
+
+  function fakeConnect(host: string) {
+    return (connectStub || (() => {}))(host);
+  }
+  let connectStub: Function;
+  let http2: typeof http2Types;
+  before(() => {
+    http2 = proxyquire('../src/http2', {
+      http2: {
+        connect: fakeConnect,
+      },
+    });
+  });
+
+  let requestStream: Readable;
+  beforeEach(() => {
+    // Create a naive ClientHttp2Session that returns an empty stream.
+    // `requestStream` is visible to tests can poke at it.
+    connectStub = () => {
+      const client = new FakeClient();
+      client.request = () => {
+        requestStream = new Readable();
+        requestStream._read = () => {};
+        return requestStream;
+      };
+      return client;
+    };
+    // All sessions are cached by host for a period of time, so clean up the
+    // cache inbetween each test.
+    Object.keys(http2.sessions).forEach(x => {
+      delete http2.sessions[x];
+    });
+  });
+
+  const host = 'https://example.com';
+  const path = '/tasks';
+  const url = host + path;
+
+  it('should set the expected headers', async () => {
+    let stream: EventEmitter;
+    connectStub = (connectHost: string) => {
+      assert.strictEqual(host, connectHost);
+      const client = new FakeClient();
+      client.request = (headers: coreHttp2.OutgoingHttpHeaders) => {
+        assert.strictEqual(headers[HTTP2_HEADER_PATH], path);
+        assert.strictEqual(headers[HTTP2_HEADER_METHOD], 'GET');
+        assert.strictEqual(
+          headers[HTTP2_HEADER_CONTENT_TYPE],
+          'application/json'
+        );
+        stream = new EventEmitter();
+        return stream;
+      };
+      return client;
+    };
+    // Give it a tick or two to work things out
+    setImmediate(() => {
+      stream.emit('response', {[HTTP2_HEADER_STATUS]: 200});
+      stream.emit('data', Buffer.from(JSON.stringify({hello: 'world'})));
+      stream.emit('end');
+    });
+    await http2.request({url});
+  });
+
+  it('should auto-decode a gzip stream', async () => {
+    const responseData = {hello: 'world'};
+    const resPromise = http2.request({url});
+    requestStream.emit('response', {
+      [HTTP2_HEADER_STATUS]: 200,
+      [HTTP2_HEADER_CONTENT_ENCODING]: 'gzip',
+    });
+    const content = gzipSync(Buffer.from(JSON.stringify(responseData)));
+    requestStream.push(content);
+    requestStream.push(null);
+    const res = await resPromise;
+    assert.deepStrictEqual(res.data, responseData);
+  });
+
+  it('should cache sessions', async () => {
+    const resPromise = http2.request({url});
+    assert.strictEqual(Object.keys(http2.sessions).length, 1);
+    assert.strictEqual(Object.keys(http2.sessions)[0], 'example.com');
+    requestStream.emit('response', {
+      [HTTP2_HEADER_STATUS]: 200,
+    });
+    requestStream.push(Buffer.from('{}'));
+    requestStream.push(null);
+    await resPromise;
+  });
+
+  it('should remove sessions from the cache after a while', async () => {
+    const resPromise = http2.request({url});
+    requestStream.emit('response', {
+      [HTTP2_HEADER_STATUS]: 200,
+    });
+    requestStream.push(Buffer.from('{}'));
+    requestStream.push(null);
+    await resPromise;
+    await new Promise(r => setTimeout(r, 500));
+    assert.strictEqual(Object.keys(http2.sessions).length, 0);
+  });
+
+  it('should remove sessions if they emit an error', async () => {
+    const resPromise = http2.request({url});
+    requestStream.emit('response', {
+      [HTTP2_HEADER_STATUS]: 200,
+    });
+    requestStream.push(Buffer.from('{}'));
+    requestStream.push(null);
+    await resPromise;
+    http2.sessions['example.com'].client.emit('error', new Error('😱'));
+    assert.strictEqual(Object.keys(http2.sessions).length, 0);
+  });
+
+  it('should remove sessions on goaway', async () => {
+    const resPromise = http2.request({url});
+    requestStream.emit('response', {
+      [HTTP2_HEADER_STATUS]: 200,
+    });
+    requestStream.push(Buffer.from('{}'));
+    requestStream.push(null);
+    await resPromise;
+    http2.sessions['example.com'].client.emit('goaway');
+    assert.strictEqual(Object.keys(http2.sessions).length, 0);
+  });
+
+  it('should encode querystring parameters', async () => {
+    let stream!: EventEmitter;
+    connectStub = () => {
+      const client = new FakeClient();
+      client.request = (headers: coreHttp2.OutgoingHttpHeaders) => {
+        assert.strictEqual(headers[HTTP2_HEADER_PATH], '/tasks?hello=world');
+        stream = new EventEmitter();
+        return stream;
+      };
+      return client;
+    };
+    const reqPromise = http2.request({
+      url,
+      params: {
+        hello: 'world',
+      },
+    });
+    stream.emit('response', {[HTTP2_HEADER_STATUS]: 200});
+    stream.emit('data', Buffer.from(JSON.stringify({hello: 'world'})));
+    stream.emit('end');
+    await reqPromise;
+  });
+
+  it('should reject the promise on stream errors', async () => {
+    const resPromise = http2.request({url});
+    requestStream.emit('response', {
+      [HTTP2_HEADER_STATUS]: 200,
+    });
+    const error = new Error('🚨');
+    requestStream.emit('error', error);
+    await assert.rejects(resPromise, /🚨/);
+  });
+
+  it('should reject the promise on non-2xx status codes', async () => {
+    const resPromise = http2.request({url});
+    requestStream.emit('response', {
+      [HTTP2_HEADER_STATUS]: 418,
+    });
+    requestStream.push(Buffer.from('{}'));
+    requestStream.push(null);
+    await assert.rejects(resPromise, /status code 418/);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "system-test/*.ts",
     "samples-test/*.ts",
     "browser-test/*.ts",
-    "browser-test/**/*.ts"
+    "browser-test/**/*.ts",
+    "benchmark/*.ts"
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,11 +33,12 @@ module.exports = {
     child_process: 'empty',
     fs: 'empty',
     crypto: 'empty',
+    http2: 'empty',
   },
   module: {
     rules: [
       {
-        test: /src\/crypto\/node\/crypto/,
+        test: /src\/http2/,
         use: 'null-loader',
       },
       {


### PR DESCRIPTION
No really, for real this time.   This adds support for HTTP/2, behind a boolean to the request options.  From the user's perspective, the only thing that's different is the flag:

```js
const {google} = require('googleapis');
const drive = google.drive('v3');
const res = await drive.files.list({
  http2: true
});
```

Everything mostly should follow the same types and usage.  The feature is flagged as experimental, so users will get a trace warning when they use it.  

The HTTP 1.1 style abstraction is provided by a HTTP2 client that gets cached when called.  If the client isn't used within 500ms of the previous request, connections are closed.  This allows for no change to the API surface, while still getting the performance gains for batch workloads where many calls are made in a tighter loop.  It's possible we should make this value configurable, this was just a start.  I want to get this in front of customers, and see what the response looks like.  

Just to get a feel for how this works - it now has benchmarks!  For sending ~50 simultaneous requests, the HTTP/2 code is on average about twice as fast, and not optimized yet at all:

```
> node build/benchmark/bench.js

[
   501,  497, 531, 534,  729,  891,  547,  895,
   880,  891, 885, 891,  744,  893,  578,  574,
   618,  579, 607, 609,  593,  614,  609,  607,
   613,  622, 620, 616,  644,  625,  640,  623,
   680,  635, 640, 644,  688,  646,  685,  678,
   690,  674, 689, 680, 1726, 1779, 1770, 1831,
  1744, 1837
]
HTTP 1.1 Avg: 800.32
(node:77425) GOOG_HTTP2: 
      The HTTP/2 API in googleapis is unstable! This is an early implementation
      that should not be used in production.  It may change in unpredictable
      ways. Please only use this for experimentation.
    
(Use `node --trace-warnings ...` to show where the warning was created)
[
  160, 550, 547, 534, 531, 520, 518, 506,
  503, 166, 495, 488, 477, 474, 452, 448,
  164, 437, 434, 424, 421, 410, 407, 399,
  394, 381, 378, 365, 361, 350, 347, 345,
  302, 299, 287, 336, 285, 271, 178, 319,
  333, 268, 265, 248, 245, 229, 227, 224,
  208, 192
]
HTTP 2 Avg: 362.04
```