### PR TITLE
fix: update google-auth-library to v7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,13 +38,15 @@
   "dependencies": {
     "extend": "^3.0.2",
     "gaxios": "^4.0.0",
-    "google-auth-library": "^6.0.0",
+    "google-auth-library": "^7.0.2",
     "qs": "^6.7.0",
     "url-template": "^2.0.8",
     "uuid": "^8.0.0"
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.9",
+    "@microsoft/api-documenter": "^7.8.10",
+    "@microsoft/api-extractor": "^7.8.10",
     "@types/execa": "^0.9.0",
     "@types/extend": "^3.0.1",
     "@types/mocha": "^8.0.0",
@@ -77,16 +79,14 @@
     "ncp": "^2.0.0",
     "nock": "^13.0.0",
     "null-loader": "^4.0.0",
-    "puppeteer": "^7.0.0",
     "proxyquire": "^2.1.3",
+    "puppeteer": "^7.0.0",
     "sinon": "^9.0.2",
     "tmp": "^0.2.0",
     "ts-loader": "^8.0.0",
     "typescript": "^3.8.3",
     "webpack": "^4.35.0",
-    "webpack-cli": "^4.0.0",
-    "@microsoft/api-documenter": "^7.8.10",
-    "@microsoft/api-extractor": "^7.8.10"
+    "webpack-cli": "^4.0.0"
   },
   "engines": {
     "node": ">=10.10.0"

--- a/src/api.ts
+++ b/src/api.ts
@@ -12,7 +12,11 @@
 // limitations under the License.
 
 import {GaxiosOptions, GaxiosResponse} from 'gaxios';
-import {OAuth2Client, GoogleAuth} from 'google-auth-library';
+import {
+  OAuth2Client,
+  GoogleAuth,
+  BaseExternalAccountClient,
+} from 'google-auth-library';
 
 import {Endpoint} from './endpoint';
 
@@ -40,7 +44,7 @@ export interface APIRequestContext {
  * and our `auth` options.
  */
 export interface GlobalOptions extends MethodOptions {
-  auth?: GoogleAuth | OAuth2Client | string;
+  auth?: GoogleAuth | OAuth2Client | BaseExternalAccountClient | string;
 }
 
 export interface MethodOptions extends GaxiosOptions {

--- a/src/authplus.ts
+++ b/src/authplus.ts
@@ -12,9 +12,13 @@
 // limitations under the License.
 
 import {
+  AwsClient,
+  BaseExternalAccountClient,
   Compute,
+  ExternalAccountClient,
   GoogleAuth,
   GoogleAuthOptions,
+  IdentityPoolClient,
   JWT,
   OAuth2Client,
   ProjectIdCallback,
@@ -26,6 +30,9 @@ export class AuthPlus extends GoogleAuth {
   Compute = Compute;
   OAuth2 = OAuth2Client;
   GoogleAuth = GoogleAuth;
+  AwsClient = AwsClient;
+  IdentityPoolClient = IdentityPoolClient;
+  ExternalAccountClient = ExternalAccountClient;
 
   private _cachedAuth?: GoogleAuth;
 
@@ -35,7 +42,7 @@ export class AuthPlus extends GoogleAuth {
    */
   async getClient(
     options?: GoogleAuthOptions
-  ): Promise<Compute | JWT | UserRefreshClient> {
+  ): Promise<Compute | JWT | UserRefreshClient | BaseExternalAccountClient> {
     this._cachedAuth = new GoogleAuth(options);
     return this._cachedAuth.getClient();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,10 @@ export {
   UserRefreshClient,
   DefaultTransporter,
   GoogleAuth,
+  ExternalAccountClient,
+  BaseExternalAccountClient,
+  IdentityPoolClient,
+  AwsClient,
 } from 'google-auth-library';
 export {GaxiosPromise} from 'gaxios';
 export {

--- a/test/test.authplus.ts
+++ b/test/test.authplus.ts
@@ -34,6 +34,9 @@ describe(__filename, () => {
     assert.ok(auth.Compute);
     assert.ok(auth.OAuth2);
     assert.ok(auth.GoogleAuth);
+    assert.ok(auth.AwsClient);
+    assert.ok(auth.IdentityPoolClient);
+    assert.ok(auth.ExternalAccountClient);
   });
 
   it('should get a new client', async () => {


### PR DESCRIPTION
Update dependency to google-auth-library to `v7.0.2`.
This also requires adding `BaseExternalAccountClient` as an acceptable `AuthClient` in `AuthPlus#getClient()` and extending `GlobalOptions#auth`.
To be consistent with the rest of the code:
- New AuthClients (`AwsClient`, `IdentityPoolClient` and `ExternalAccountClient`) were also exposed in the `AuthPlus` class.
- New AuthClients were re-exported in index.ts.
