### PR TITLE
fix: export additional gaxios types

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^4.0.2",
     "linkinator": "^2.0.0",
-    "mocha": "^8.0.0",
+    "mocha": "^8.3.2",
     "mv": "^2.1.1",
     "ncp": "^2.0.0",
     "nock": "^13.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,15 @@ export {
   IdentityPoolClient,
   AwsClient,
 } from 'google-auth-library';
-export {GaxiosPromise} from 'gaxios';
+export {
+  GaxiosPromise,
+  Gaxios,
+  GaxiosError,
+  GaxiosOptions,
+  GaxiosResponse,
+  Headers,
+  RetryConfig,
+} from 'gaxios';
 export {
   APIEndpoint,
   APIRequestContext,


### PR DESCRIPTION
This is a nod towards https://github.com/googleapis/google-api-nodejs-client/issues/2367