### PR TITLE
fix: mark the HTTP/2 support as stable

### DIFF
--- a/src/http2.ts
+++ b/src/http2.ts
@@ -46,7 +46,6 @@ export interface SessionData {
  * @private
  */
 export const sessions: {[index: string]: SessionData} = {};
-let warned = false;
 
 /**
  * Public method to make an http2 request.
@@ -55,17 +54,6 @@ let warned = false;
 export async function request<T>(
   config: GaxiosOptions
 ): Promise<GaxiosResponse<T>> {
-  // Make sure users know this API is unstable
-  if (!warned) {
-    const message = `
-      The HTTP/2 API in googleapis is unstable! This is an early implementation
-      that should not be used in production.  It may change in unpredictable
-      ways. Please only use this for experimentation.
-    `;
-    process.emitWarning(message, 'GOOG_HTTP2');
-    warned = true;
-  }
-
   const opts = extend(true, {}, config);
   opts.validateStatus = opts.validateStatus || validateStatus;
   opts.responseType = opts.responseType || 'json';


### PR DESCRIPTION
The API is now over a [year old](https://github.com/googleapis/nodejs-googleapis-common/commit/4d33ffa237e53f6beb88a4e32d6cc7f31f05a8d6), and we've had no complaints on the surface.  There are many tests, and it seems to work great.  