### PR TITLE
test: increase asserted bundle size

### DIFF
--- a/system-test/test.kitchen.ts
+++ b/system-test/test.kitchen.ts
@@ -51,7 +51,7 @@ describe('pack and install', () => {
     await execa('npx', ['webpack'], {cwd: `${stagingPath}/`, stdio: 'inherit'});
     const bundle = path.join(stagingPath, 'dist', 'bundle.min.js');
     const stat = fs.statSync(bundle);
-    assert(stat.size < 256 * 1024);
+    assert(stat.size < 300 * 1024);
   });
 
   /**


### PR DESCRIPTION
The bundle of nodejs-googleapis-common is just over 256Kb now.
This is likely from natural growth of the auth library.

Fixes googleapis/google-cloud-node-core#785 