### PR TITLE
feat: add universe support to googleapis libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "extend": "^3.0.2",
     "gaxios": "^6.0.3",
-    "google-auth-library": "^9.0.0",
+    "google-auth-library": "^9.7.0",
     "qs": "^6.7.0",
     "url-template": "^2.0.8",
     "uuid": "^9.0.0"
@@ -69,7 +69,7 @@
     "karma-mocha": "^2.0.0",
     "karma-remap-coverage": "^0.1.5",
     "karma-sourcemap-loader": "^0.4.0",
-    "karma-webpack": "^5.0.0",
+    "karma-webpack": "^4.0.0",
     "linkinator": "^3.1.0",
     "mocha": "^9.2.2",
     "mv": "^2.1.1",
@@ -82,7 +82,7 @@
     "tmp": "^0.2.0",
     "ts-loader": "^8.0.0",
     "typescript": "5.1.6",
-    "webpack": "^5.30.0",
+    "webpack": "^4.0.0",
     "webpack-cli": "^4.0.0"
   },
   "engines": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -45,6 +45,8 @@ export interface APIRequestContext {
  */
 export interface GlobalOptions extends MethodOptions {
   auth?: GoogleAuth | OAuth2Client | BaseExternalAccountClient | string;
+  universeDomain?: string;
+  universe_domain?: string;
 }
 
 export interface MethodOptions extends GaxiosOptions {

--- a/src/authplus.ts
+++ b/src/authplus.ts
@@ -47,6 +47,7 @@ export class AuthPlus extends GoogleAuth {
     Compute | JWT | UserRefreshClient | BaseExternalAccountClient | Impersonated
   > {
     this._cachedAuth = new GoogleAuth(options);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return this._cachedAuth.getClient() as any;
   }
 

--- a/test/test.apirequest.ts
+++ b/test/test.apirequest.ts
@@ -485,4 +485,265 @@ describe('createAPIRequest', () => {
       assert.ok(stub.calledOnce);
     });
   });
+
+  describe('TPC', () => {
+    it('should allow setting universeDomain', async () => {
+      const gduUrl = 'https://api.googleapis.com/path?param=value#extra';
+      const expectedUniverseUrl =
+        'https://api.universe.com/path?param=value#extra';
+      const auth = new GoogleAuth();
+      const getUniverseDomainStub = sandbox
+        .stub(auth, 'getUniverseDomain')
+        .resolves('universe.com');
+      sandbox.stub(auth, 'getRequestHeaders').resolves({});
+      const requestStub = sandbox
+        .stub(auth, 'request')
+        .resolves({data: fakeResponse} as GaxiosResponse);
+      const result = await createAPIRequest<FakeParams>({
+        options: {url: gduUrl},
+        params: {},
+        requiredParams: [],
+        pathParams: [],
+        context: {
+          _options: {
+            universeDomain: 'universe.com',
+            auth,
+          },
+        },
+      });
+      assert.strictEqual(result.data, fakeResponse as {});
+      assert.ok(getUniverseDomainStub.calledOnce);
+      assert.ok(requestStub.calledOnce);
+      assert.strictEqual(
+        requestStub.getCall(0).args[0].url,
+        expectedUniverseUrl
+      );
+      assert(result);
+    });
+
+    it('should allow setting universe_domain', async () => {
+      const gduUrl = 'https://api.googleapis.com/path?param=value#extra';
+      const expectedUniverseUrl =
+        'https://api.universe.com/path?param=value#extra';
+      const auth = new GoogleAuth();
+      const getUniverseDomainStub = sandbox
+        .stub(auth, 'getUniverseDomain')
+        .resolves('universe.com');
+      sandbox.stub(auth, 'getRequestHeaders').resolves({});
+      const requestStub = sandbox
+        .stub(auth, 'request')
+        .resolves({data: fakeResponse} as GaxiosResponse);
+      const result = await createAPIRequest<FakeParams>({
+        options: {url: gduUrl},
+        params: {},
+        requiredParams: [],
+        pathParams: [],
+        context: {
+          _options: {
+            universe_domain: 'universe.com',
+            auth,
+          },
+        },
+      });
+      assert.strictEqual(result.data, fakeResponse as {});
+      assert.ok(getUniverseDomainStub.calledOnce);
+      assert.ok(requestStub.calledOnce);
+      assert.strictEqual(
+        requestStub.getCall(0).args[0].url,
+        expectedUniverseUrl
+      );
+      assert(result);
+    });
+
+    it('should disallow setting both universeDomain and universe_domain', async () => {
+      const gduUrl = 'https://api.googleapis.com/path?param=value#extra';
+      assert.rejects(
+        createAPIRequest<FakeParams>({
+          options: {url: gduUrl},
+          params: {},
+          requiredParams: [],
+          pathParams: [],
+          context: {
+            _options: {
+              universe_domain: 'universe1.com',
+              universeDomain: 'universe2.com',
+            },
+          },
+        }),
+        (err: Error) => {
+          assert.ok(err.message.includes('but not both'));
+          return true;
+        }
+      );
+    });
+
+    if (typeof process === 'object' && typeof process.env === 'object') {
+      it('should allow setting GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variable', async () => {
+        const saved = process.env['GOOGLE_CLOUD_UNIVERSE_DOMAIN'];
+        process.env['GOOGLE_CLOUD_UNIVERSE_DOMAIN'] = 'universe.com';
+        const gduUrl = 'https://api.googleapis.com/path?param=value#extra';
+        const expectedUniverseUrl =
+          'https://api.universe.com/path?param=value#extra';
+        const auth = new GoogleAuth();
+        const getUniverseDomainStub = sandbox
+          .stub(auth, 'getUniverseDomain')
+          .resolves('universe.com');
+        sandbox.stub(auth, 'getRequestHeaders').resolves({});
+        const requestStub = sandbox
+          .stub(auth, 'request')
+          .resolves({data: fakeResponse} as GaxiosResponse);
+        const result = await createAPIRequest<FakeParams>({
+          options: {url: gduUrl},
+          params: {},
+          requiredParams: [],
+          pathParams: [],
+          context: {
+            _options: {
+              auth,
+            },
+          },
+        });
+        if (saved) {
+          process.env['GOOGLE_CLOUD_UNIVERSE_DOMAIN'] = saved;
+        } else {
+          delete process.env['GOOGLE_CLOUD_UNIVERSE_DOMAIN'];
+        }
+        assert.strictEqual(result.data, fakeResponse as {});
+        assert.ok(getUniverseDomainStub.calledOnce);
+        assert.ok(requestStub.calledOnce);
+        assert.strictEqual(
+          requestStub.getCall(0).args[0].url,
+          expectedUniverseUrl
+        );
+        assert(result);
+      });
+
+      it('configuration in code has priority over GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variable', async () => {
+        const saved = process.env['GOOGLE_CLOUD_UNIVERSE_DOMAIN'];
+        process.env['GOOGLE_CLOUD_UNIVERSE_DOMAIN'] = 'wrong-universe.com';
+        const gduUrl = 'https://api.googleapis.com/path?param=value#extra';
+        const expectedUniverseUrl =
+          'https://api.universe.com/path?param=value#extra';
+        const auth = new GoogleAuth();
+        const getUniverseDomainStub = sandbox
+          .stub(auth, 'getUniverseDomain')
+          .resolves('universe.com');
+        sandbox.stub(auth, 'getRequestHeaders').resolves({});
+        const requestStub = sandbox
+          .stub(auth, 'request')
+          .resolves({data: fakeResponse} as GaxiosResponse);
+        const result = await createAPIRequest<FakeParams>({
+          options: {url: gduUrl},
+          params: {},
+          requiredParams: [],
+          pathParams: [],
+          context: {
+            _options: {
+              universeDomain: 'universe.com',
+              auth,
+            },
+          },
+        });
+        if (saved) {
+          process.env['GOOGLE_CLOUD_UNIVERSE_DOMAIN'] = saved;
+        } else {
+          delete process.env['GOOGLE_CLOUD_UNIVERSE_DOMAIN'];
+        }
+        assert.strictEqual(result.data, fakeResponse as {});
+        assert.ok(getUniverseDomainStub.calledOnce);
+        assert.ok(requestStub.calledOnce);
+        assert.strictEqual(
+          requestStub.getCall(0).args[0].url,
+          expectedUniverseUrl
+        );
+        assert(result);
+      });
+    }
+
+    it('should validate universe domain received from auth library', async () => {
+      const gduUrl = 'https://api.googleapis.com/path?param=value#extra';
+      const auth = new GoogleAuth();
+      sandbox.stub(auth, 'getUniverseDomain').resolves('wrong-universe.com');
+      await assert.rejects(
+        createAPIRequest<FakeParams>({
+          options: {url: gduUrl},
+          params: {},
+          requiredParams: [],
+          pathParams: [],
+          context: {
+            _options: {
+              universeDomain: 'universe.com',
+              auth,
+            },
+          },
+        }),
+        (err: Error) => {
+          assert.ok(
+            err.message.includes(
+              'The configured universe domain (universe.com) does not match the universe domain ' +
+                'found in the credentials (wrong-universe.com)'
+            )
+          );
+          return true;
+        }
+      );
+    });
+
+    it('should not leak TPC universe credentials to googleapis.com universe', async () => {
+      const gduUrl = 'https://api.googleapis.com/path?param=value#extra';
+      const auth = new GoogleAuth();
+      sandbox.stub(auth, 'getUniverseDomain').resolves('wrong-universe.com');
+      await assert.rejects(
+        createAPIRequest<FakeParams>({
+          options: {url: gduUrl},
+          params: {},
+          requiredParams: [],
+          pathParams: [],
+          context: {
+            _options: {
+              auth,
+            },
+          },
+        }),
+        (err: Error) => {
+          assert.ok(
+            err.message.includes(
+              'The configured universe domain (googleapis.com) does not match the universe domain ' +
+                'found in the credentials (wrong-universe.com)'
+            )
+          );
+          return true;
+        }
+      );
+    });
+
+    it('should not leak googleapis.com credentials to TPC universe', async () => {
+      const gduUrl = 'https://api.googleapis.com/path?param=value#extra';
+      const auth = new GoogleAuth();
+      sandbox.stub(auth, 'getUniverseDomain').resolves('googleapis.com');
+      await assert.rejects(
+        createAPIRequest<FakeParams>({
+          options: {url: gduUrl},
+          params: {},
+          requiredParams: [],
+          pathParams: [],
+          context: {
+            _options: {
+              universe_domain: 'wrong-universe.com',
+              auth,
+            },
+          },
+        }),
+        (err: Error) => {
+          assert.ok(
+            err.message.includes(
+              'The configured universe domain (wrong-universe.com) does not match the universe domain ' +
+                'found in the credentials (googleapis.com)'
+            )
+          );
+          return true;
+        }
+      );
+    });
+  });
 });


### PR DESCRIPTION
Adding a global option `universeDomain` (can also be spelled as `universe_domain`). Example usage with `google-api-nodejs-client` (for Cloud KMS):

```ts
import * as cloudkms from '@googleapis/cloudkms';

const googleAuth = new auth.GoogleAuth({
  scopes: [
    'https://www.googleapis.com/auth/cloud-platform',
    'https://www.googleapis.com/auth/cloudkms',
  ],
});
const kms = cloudkms.cloudkms({
  auth: googleAuth,
  version: 'v1',
  universeDomain: 'example.com',  // use your Trusted Partner Cloud universe domain
});
const project = await googleAuth.getProjectId();
const location = 'some-existing-location-such-as-us-central1';
const result = await kms.projects.locations.keyRings.list({
  parent: `projects/${project}/locations/${location}`,
});
console.log(result.data);
```

The universe domain can be also configured with `GOOGLE_CLOUD_UNIVERSE_DOMAIN` environment variable.

Note that for services which have modern libraries published to `@google-cloud/` NPM organization (e.g. `@google-cloud/kms`), we recommend using them and not `@googleapis` libraries. Still adding this feature to `@googleapis` for completeness.