### PR TITLE
chore: use Node.js's built-in 'querystring' module

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "extend": "^3.0.2",
     "gaxios": "^6.0.3",
     "google-auth-library": "^9.7.0",
-    "qs": "^6.7.0",
     "url-template": "^2.0.8",
     "uuid": "^9.0.0"
   },
@@ -51,7 +50,6 @@
     "@types/ncp": "^2.0.1",
     "@types/nock": "^11.0.0",
     "@types/proxyquire": "^1.3.28",
-    "@types/qs": "^6.5.3",
     "@types/sinon": "^17.0.0",
     "@types/tmp": "0.2.6",
     "@types/url-template": "^2.0.28",

--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -13,7 +13,7 @@
 
 import {GaxiosPromise, Headers} from 'gaxios';
 import {DefaultTransporter, OAuth2Client} from 'google-auth-library';
-import * as qs from 'qs';
+import * as querystring from 'querystring';
 import * as stream from 'stream';
 import * as urlTemplate from 'url-template';
 import * as uuid from 'uuid';
@@ -186,7 +186,9 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
   // This serializer also encodes spaces in the querystring as `%20`,
   // whereas the default serializer in gaxios encodes to a `+`.
   options.paramsSerializer = params => {
-    return qs.stringify(params, {arrayFormat: 'repeat'});
+    return querystring.stringify(params, undefined, undefined, {
+      encodeURIComponent,
+    });
   };
 
   // delete path params from the params object so they do not end up in query

--- a/src/http2.ts
+++ b/src/http2.ts
@@ -14,7 +14,7 @@
 import * as http2 from 'http2';
 import * as zlib from 'zlib';
 import {URL} from 'url';
-import * as qs from 'qs';
+import * as querystring from 'querystring';
 import * as extend from 'extend';
 import {Stream, Readable} from 'stream';
 import * as util from 'util';
@@ -69,12 +69,17 @@ export async function request<T>(
     clearTimeout(sessionData.timeoutHandle);
   }
 
-  // Assemble the querystring based on config.params.  We're using the
-  // `qs` module to make life a little easier.
+  // Assemble the querystring based on config.params.
   let pathWithQs = url.pathname;
   if (config.params && Object.keys(config.params).length > 0) {
-    const serializer = config.paramsSerializer || qs.stringify;
-    const q = serializer(opts.params);
+    let q: string;
+    if (config.paramsSerializer) {
+      q = config.paramsSerializer(opts.params);
+    } else {
+      q = querystring.stringify(opts.params, undefined, undefined, {
+        encodeURIComponent,
+      });
+    }
     pathWithQs += `?${q}`;
   }
 


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-googleapis-common/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes googleapis/google-cloud-node-core#759 🦕

This pull request suggests using Node.js's built-in `querystring` module for serializing query strings. It's used in a way that uses `%20` to encode spaces instead of Gaxios's default `+`.

A test for `http2.ts`'s custom parameter serialization functionality is added. As a result the overall test coverage goes up a bit.