### PR TITLE
feat: switch to picoquery for query string handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "extend": "^3.0.2",
     "gaxios": "^6.0.3",
     "google-auth-library": "^9.7.0",
-    "qs": "^6.7.0",
+    "picoquery": "^1.4.0",
     "url-template": "^2.0.8",
     "uuid": "^9.0.0"
   },

--- a/src/apirequest.ts
+++ b/src/apirequest.ts
@@ -13,7 +13,7 @@
 
 import {GaxiosPromise, Headers} from 'gaxios';
 import {DefaultTransporter, OAuth2Client} from 'google-auth-library';
-import * as qs from 'qs';
+import * as pq from 'picoquery';
 import * as stream from 'stream';
 import * as urlTemplate from 'url-template';
 import * as uuid from 'uuid';
@@ -186,7 +186,11 @@ async function createAPIRequestAsync<T>(parameters: APIRequestParams) {
   // This serializer also encodes spaces in the querystring as `%20`,
   // whereas the default serializer in gaxios encodes to a `+`.
   options.paramsSerializer = params => {
-    return qs.stringify(params, {arrayFormat: 'repeat'});
+    return pq.stringify(params, {
+      arrayRepeat: true,
+      arrayRepeatSyntax: 'repeat',
+      nestingSyntax: 'js',
+    });
   };
 
   // delete path params from the params object so they do not end up in query

--- a/src/http2.ts
+++ b/src/http2.ts
@@ -14,7 +14,7 @@
 import * as http2 from 'http2';
 import * as zlib from 'zlib';
 import {URL} from 'url';
-import * as qs from 'qs';
+import * as pq from 'picoquery';
 import * as extend from 'extend';
 import {Stream, Readable} from 'stream';
 import * as util from 'util';
@@ -70,10 +70,10 @@ export async function request<T>(
   }
 
   // Assemble the querystring based on config.params.  We're using the
-  // `qs` module to make life a little easier.
+  // `pq` module to make life a little easier.
   let pathWithQs = url.pathname;
   if (config.params && Object.keys(config.params).length > 0) {
-    const serializer = config.paramsSerializer || qs.stringify;
+    const serializer = config.paramsSerializer || pq.stringify;
     const q = serializer(opts.params);
     pathWithQs += `?${q}`;
   }


### PR DESCRIPTION
By switching to picoquery, we can gain a substantial perf boost (it is [much faster](https://github.com/43081j/picoquery?tab=readme-ov-file#stringify) than qs, and about the same speed as `fast-querystring`). It is based on `fast-querystring`, but with support for nesting.

Similarly, we can drop a few dependencies.

Note that this is part of the ongoing [ecosystem-cleanup](https://github.com/43081j/ecosystem-cleanup/).

**Important note:**

The behaviour will slightly change here in that pq is stricter with syntax than qs. For example, it makes no sense to mix these two syntaxes: `foo=1&foo=2&foo[]=3`. qs supports this at the cost of speed, while pq requires you to choose one.

If you don't yet want to change this behaviour, there is another PR moving to `neoqs` instead. That will keep the same interface and behaviour with a much smaller change in performance.

let me know and i'm happy to work with either!
