### PR TITLE
chore: remove `execa`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-methods": "^7.18.6",
-    "@types/execa": "^2.0.0",
     "@types/extend": "^3.0.1",
     "@types/mocha": "^10.0.10",
     "@types/mv": "^2.1.0",
@@ -55,7 +54,6 @@
     "@types/url-template": "^2.0.28",
     "c8": "^10.1.3",
     "codecov": "^3.5.0",
-    "execa": "^5.0.0",
     "gts": "^6.0.2",
     "http2spy": "^2.0.0",
     "is-docker": "^2.0.0",

--- a/system-test/test.kitchen.ts
+++ b/system-test/test.kitchen.ts
@@ -14,7 +14,8 @@
 
 import * as assert from 'assert';
 import {describe, it, before, after} from 'mocha';
-import * as execa from 'execa';
+import {execFileSync} from 'child_process';
+
 import * as fs from 'fs';
 import * as mv from 'mv';
 import {ncp} from 'ncp';
@@ -37,18 +38,24 @@ describe('pack and install', () => {
    */
   before('should be able to use the d.ts', async () => {
     console.log(`${__filename} staging area: ${stagingPath}`);
-    await execa('npm', ['pack'], {stdio: 'inherit'});
+    execFileSync('npm', ['pack']);
     const tarball = `${pkg.name}-${pkg.version}.tgz`;
     // stagingPath can be on another filesystem so fs.rename() will fail
     // with EXDEV, hence we use `mv` module here.
     await mvp(tarball, `${stagingPath}/googleapis-common.tgz`);
     await ncpp('system-test/fixtures/kitchen', `${stagingPath}/`);
-    await execa('npm', ['install'], {cwd: `${stagingPath}/`, stdio: 'inherit'});
+    execFileSync('npm', ['install'], {
+      cwd: `${stagingPath}/`,
+      stdio: 'inherit',
+    });
   });
 
   it('should be able to webpack the library', async () => {
     // we expect npm install is executed in the before hook
-    await execa('npx', ['webpack'], {cwd: `${stagingPath}/`, stdio: 'inherit'});
+    execFileSync('npx', ['webpack'], {
+      cwd: `${stagingPath}/`,
+      stdio: 'inherit',
+    });
     const bundle = path.join(stagingPath, 'dist', 'bundle.min.js');
     const stat = fs.statSync(bundle);
     assert(stat.size < 400 * 1024);


### PR DESCRIPTION
Removing `execa` in favor of the native `child_process` module

🦕
